### PR TITLE
Don't need Lambda to Tableau sg

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -205,18 +205,3 @@ resource "aws_security_group" "sgrp" {
     Name = "sg-${local.naming_suffix}"
   }
 }
-
-resource "aws_security_group_rule" "allow_lambda" {
-  type        = "ingress"
-  description = "Postgres from the Lambda subnet"
-  from_port   = "${var.rds_from_port}"
-  to_port     = "${var.rds_to_port}"
-  protocol    = "${var.rds_protocol}"
-
-  cidr_blocks = [
-    "${var.dq_lambda_subnet_cidr}",
-    "${var.dq_lambda_subnet_cidr_az2}",
-  ]
-
-  security_group_id = "${aws_security_group.sgrp.id}"
-}


### PR DESCRIPTION
This ingress priv is already in rds.tf. It's not required in main.tf which is where Tableau is. We don't need Lambda to be able to talk to Tableau, only RDS.